### PR TITLE
fix strconv.Atoi parsing error when no MR

### DIFF
--- a/pkg/platform/ci.go
+++ b/pkg/platform/ci.go
@@ -33,8 +33,7 @@ func complementWithCIEnv(ci *config.CI) error {
 		ci.SHA = os.Getenv("CI_COMMIT_SHA")
 	}
 
-	if ci.MRNumber <= 0 {
-		mr := os.Getenv("CI_MERGE_REQUEST_IID")
+	if mr := os.Getenv("CI_MERGE_REQUEST_IID"); mr != "" && ci.MRNumber <= 0 {
 		a, err := strconv.Atoi(mr)
 		if err != nil {
 			return fmt.Errorf("parse CI_MERGE_REQUEST_IID %s: %w", mr, err)


### PR DESCRIPTION
Hi!. it seems to fail to apply when we merge MR, and this is quick fix.

error log:

```
time="2022-05-06T04:26:33Z" level=error msg="parse CI_MERGE_REQUEST_IID : strconv.Atoi: parsing \"\": invalid syntax"
```

