### PR TITLE
Comment to associated MR when push pipeline

### DIFF
--- a/pkg/notifier/gitlab/comment.go
+++ b/pkg/notifier/gitlab/comment.go
@@ -18,21 +18,33 @@ type PostOptions struct {
 
 // Post posts comment
 func (g *CommentService) Post(body string, opt PostOptions) error {
-	if opt.Number != 0 {
-		_, _, err := g.client.API.CreateMergeRequestNote(
-			opt.Number,
-			&gitlab.CreateMergeRequestNoteOptions{Body: gitlab.String(body)},
-		)
-		return err
+	if opt.Number == 0 && opt.Revision == "" {
+		return fmt.Errorf("gitlab.comment.post: Number or Revision is required")
 	}
-	if opt.Revision != "" {
-		_, _, err := g.client.API.PostCommitComment(
-			opt.Revision,
-			&gitlab.PostCommitCommentOptions{Note: gitlab.String(body)},
-		)
-		return err
+
+	if opt.Number == 0 {
+		mrs, err := g.client.Commits.ListMergeRequestIIDsByRevision(opt.Revision)
+		if err != nil || len(mrs) == 0 {
+			return g.postForRevision(body, opt.Revision)
+		}
+
+		// Rewrite the MR number to the first MR which is associated with revision.
+		opt.Number = mrs[0]
 	}
-	return fmt.Errorf("gitlab.comment.post: Number or Revision is required")
+
+	_, _, err := g.client.API.CreateMergeRequestNote(
+		opt.Number,
+		&gitlab.CreateMergeRequestNoteOptions{Body: gitlab.String(body)},
+	)
+	return err
+}
+
+func (g *CommentService) postForRevision(body, revision string) error {
+	_, _, err := g.client.API.PostCommitComment(
+		revision,
+		&gitlab.PostCommitCommentOptions{Note: gitlab.String(body)},
+	)
+	return err
 }
 
 // Patch patches on the specific comment

--- a/pkg/notifier/gitlab/commits.go
+++ b/pkg/notifier/gitlab/commits.go
@@ -28,6 +28,22 @@ func (g *CommitsService) List(revision string) ([]string, error) {
 	return s, nil
 }
 
+func (g *CommitsService) ListMergeRequestIIDsByRevision(revision string) ([]int, error) {
+	if revision == "" {
+		return nil, errors.New("no revision specified")
+	}
+	mrs, _, err := g.client.API.ListMergeRequestsByCommit(revision)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]int, len(mrs))
+	for i, mr := range mrs {
+		result[i] = mr.IID
+	}
+	return result, nil
+}
+
 // lastOne returns the hash of the previous commit of the given commit
 func (g *CommitsService) lastOne(commits []string, revision string) (string, error) {
 	if revision == "" {

--- a/pkg/notifier/gitlab/gitlab.go
+++ b/pkg/notifier/gitlab/gitlab.go
@@ -21,6 +21,7 @@ type API interface {
 	GetLabel(labelName string, options ...gitlab.RequestOptionFunc) (*gitlab.Label, *gitlab.Response, error)
 	UpdateLabel(opt *gitlab.UpdateLabelOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Label, *gitlab.Response, error)
 	GetCommit(sha string, options ...gitlab.RequestOptionFunc) (*gitlab.Commit, *gitlab.Response, error)
+	ListMergeRequestsByCommit(sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error)
 }
 
 // GitLab represents the attribute information necessary for requesting GitLab API
@@ -114,4 +115,8 @@ func (g *GitLab) UpdateLabel(opt *gitlab.UpdateLabelOptions, options ...gitlab.R
 // GetCommit is a wrapper of https://pkg.go.dev/github.com/xanzy/go-gitlab#CommitsService.GetCommit
 func (g *GitLab) GetCommit(sha string, options ...gitlab.RequestOptionFunc) (*gitlab.Commit, *gitlab.Response, error) {
 	return g.Client.Commits.GetCommit(fmt.Sprintf("%s/%s", g.namespace, g.project), sha, options...)
+}
+
+func (g *GitLab) ListMergeRequestsByCommit(sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error) {
+	return g.Client.Commits.ListMergeRequestsByCommit(fmt.Sprintf("%s/%s", g.namespace, g.project), sha, options...)
 }

--- a/pkg/notifier/gitlab/gitlab_test.go
+++ b/pkg/notifier/gitlab/gitlab_test.go
@@ -7,10 +7,11 @@ import (
 
 type fakeAPI struct {
 	API
-	FakeCreateMergeRequestNote func(mergeRequest int, opt *gitlab.CreateMergeRequestNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error)
-	FakeListMergeRequestNotes  func(mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error)
-	FakePostCommitComment      func(sha string, opt *gitlab.PostCommitCommentOptions, options ...gitlab.RequestOptionFunc) (*gitlab.CommitComment, *gitlab.Response, error)
-	FakeListCommits            func(opt *gitlab.ListCommitsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Commit, *gitlab.Response, error)
+	FakeCreateMergeRequestNote    func(mergeRequest int, opt *gitlab.CreateMergeRequestNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error)
+	FakeListMergeRequestNotes     func(mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error)
+	FakePostCommitComment         func(sha string, opt *gitlab.PostCommitCommentOptions, options ...gitlab.RequestOptionFunc) (*gitlab.CommitComment, *gitlab.Response, error)
+	FakeListCommits               func(opt *gitlab.ListCommitsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Commit, *gitlab.Response, error)
+	FakeListMergeRequestsByCommit func(sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error)
 }
 
 func (g *fakeAPI) CreateMergeRequestNote(mergeRequest int, opt *gitlab.CreateMergeRequestNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error) {
@@ -27,6 +28,10 @@ func (g *fakeAPI) PostCommitComment(sha string, opt *gitlab.PostCommitCommentOpt
 
 func (g *fakeAPI) ListCommits(opt *gitlab.ListCommitsOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Commit, *gitlab.Response, error) {
 	return g.FakeListCommits(opt, options...)
+}
+
+func (g *fakeAPI) ListMergeRequestsByCommit(sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error) {
+	return g.FakeListMergeRequestsByCommit(sha, options...)
 }
 
 func newFakeAPI() fakeAPI {
@@ -70,6 +75,13 @@ func newFakeAPI() fakeAPI {
 				},
 			}
 			return commits, nil, nil
+		},
+		FakeListMergeRequestsByCommit: func(sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error) {
+			return []*gitlab.MergeRequest{
+				{
+					IID: 1,
+				},
+			}, nil, nil
 		},
 	}
 }


### PR DESCRIPTION
Currently, tfcmt-gitlab comments to commit hash when the pipeline is push. But, this comment is hard to find. So, I changed the destination from commit hash to MR which is associated with `CI_COMMIT_HASH`