### PR TITLE
fix: comment list pagination

### DIFF
--- a/pkg/notifier/gitlab/comment_test.go
+++ b/pkg/notifier/gitlab/comment_test.go
@@ -70,6 +70,16 @@ func TestCommentPost(t *testing.T) {
 func TestCommentList(t *testing.T) {
 	t.Parallel()
 	comments := []*gitlab.Note{
+		// page1
+		{
+			ID:   371748792,
+			Body: "comment 1",
+		},
+		{
+			ID:   371765743,
+			Body: "comment 2",
+		},
+		// page2
 		{
 			ID:   371748792,
 			Body: "comment 1",

--- a/pkg/notifier/gitlab/gitlab_test.go
+++ b/pkg/notifier/gitlab/gitlab_test.go
@@ -45,6 +45,7 @@ func newFakeAPI() fakeAPI {
 		FakeListMergeRequestNotes: func(mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error) {
 			var comments []*gitlab.Note
 			comments = []*gitlab.Note{
+				// same response to any page for now
 				{
 					ID:   371748792,
 					Body: "comment 1",
@@ -54,7 +55,16 @@ func newFakeAPI() fakeAPI {
 					Body: "comment 2",
 				},
 			}
-			return comments, nil, nil
+
+			// fake pagination with 2 pages
+			resp := &gitlab.Response{
+				NextPage: 0,
+			}
+			if opt.Page == 1 {
+				resp.NextPage = 2
+			}
+
+			return comments, resp, nil
 		},
 		FakePostCommitComment: func(sha string, opt *gitlab.PostCommitCommentOptions, options ...gitlab.RequestOptionFunc) (*gitlab.CommitComment, *gitlab.Response, error) {
 			return &gitlab.CommitComment{


### PR DESCRIPTION
SSIA

there can be same issues for other listings, but I think only comment list has problem because

* `ListCommits`: It seems that we use only last commit, so first page is enough
* `ListMergeRequestsByCommit`: no pagination function? and single page may enough